### PR TITLE
Feat/update message schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 
 - Initial release
 - Replace mongo legacy image in CI [#2](https://github.com/etalab/udata-event-consumer/pull/2)
+- Update message schemas [#3](https://github.com/etalab/udata-event-consumer/pull/3)

--- a/udata_event_consumer/dataset/event.py
+++ b/udata_event_consumer/dataset/event.py
@@ -5,58 +5,72 @@ from udata.core.dataset.models import get_resource
 log = logging.getLogger(__name__)
 
 
-def consume_message_resource_analysed(key, value):
+def concat_location(location: dict) -> str:
+    '''
+    Return an url from an object storage location object.
+    Input example:
+    {
+        "url": "http://minio:9000/",
+        "bucket": "udata",
+        "key": "data/71cacba9-4ffd-4ea8-bc3e-694425ddf006"
+    }
+    would return the following string:
+    "http://minio:9000/udata/data/71cacba9-4ffd-4ea8-bc3e-694425ddf006"
+    '''
+    return '/'.join([location['url'].strip('/'), location['bucket'], location['key']])
+
+
+def consume_message_resource_analysed(key: str, message: dict) -> None:
     '''
     Reads a message and update the resource extras with analysis information, ex:
     report location, mime, filesize, etc.
     '''
-    log.info("Consuming message analysed")
+    log.info('Consuming message analysed')
     resource = get_resource(UUID(key))
+    value = message['value']
     if resource:
-        # TODO: add extra logic here
-        for entry in value['value']:
-            if entry == 'location' and isinstance(value['value'][entry], dict):
-                resource.extras['analysis:location'] = '/'.join([
-                    value['value']['location']['url'].strip('/'),
-                    value['value']['location']['bucket'],
-                    value['value']['location']['key']])
-            elif value['value'][entry] is not None:
-                resource.extras[f'analysis:{entry}'] = value['value'][entry]
+        if message['service'] == 'udata-hydra':
+            resource.extras['analysis:error'] = value['error']
+            resource.extras['analysis:filesize'] = value['filesize']
+            resource.extras['analysis:mime'] = value['mime']
+        elif message['service'] == 'detective':
+            resource.extras['analysis:data_location'] = concat_location(value['data_location'])
+            resource.extras['analysis:report_location'] = concat_location(value['report_location'])
+            resource.extras['analysis:schema_location'] = concat_location(value['schema_location'])
+            resource.extras['analysis:encoding'] = value['encoding']
+            resource.extras['analysis:delimiter'] = value['delimiter']
+        else:
+            log.warn(f'Unexpected service for resource analysed topic for key {key}')
         resource.save()
     else:
         log.warn(f'No resource found for key {key}')
 
 
-def consume_message_resource_stored(key, value):
+def consume_message_resource_stored(key: str, message: dict) -> None:
     '''
     Reads a message and update the resource extras with the S3 stored location.
     '''
-    log.info("Consuming message stored")
+    log.info('Consuming message stored')
     resource = get_resource(UUID(key))
     if resource:
-        resource.extras['store:location'] = '/'.join([
-            value['value']['location']['netloc'].strip('/'),
-            value['value']['location']['bucket'],
-            value['value']['location']['key']])
+        resource.extras['store:location'] = concat_location(message['value']['data_location'])
         resource.save()
     else:
         log.warn(f'No resource found for key {key}')
 
 
-def consume_message_resource_checked(key, value):
+def consume_message_resource_checked(key: str, message: dict) -> None:
     '''
     Reads a message and update the resource extras with checked information, in particular:
     status, timeout, check date.
     '''
-    log.info("Consuming message checked")
+    log.info('Consuming message checked')
     resource = get_resource(UUID(key))
+    value = message['value']
     if resource:
-        if 'status' in value['value']:
-            resource.extras['check:status'] = value['value']['status']
-        if 'timeout' in value['value']:
-            resource.extras['check:timeout'] = value['value']['timeout']
-        if 'check_date' in value['meta']:
-            resource.extras['check:check_date'] = value['meta']['check_date']
+        resource.extras['check:status'] = value['status']
+        resource.extras['check:timeout'] = value['timeout']
+        resource.extras['check:check_date'] = value['check_date']
         resource.save()
     else:
         log.warn(f'No resource found for key {key}')

--- a/udata_event_consumer/dataset/event.py
+++ b/udata_event_consumer/dataset/event.py
@@ -32,7 +32,7 @@ def consume_message_resource_analysed(key: str, message: dict) -> None:
     if resource:
         if service == 'udata-hydra':
             for key in ['error', 'filesize', 'mime']:
-                if value[key]:
+                if value.get(key, None) is not None:
                     resource.extras[f'analysis:{key}'] = value[key]
         elif service == 'csvdetective':
             resource.extras['analysis:report_location'] = concat_location(value['report_location'])
@@ -69,7 +69,7 @@ def consume_message_resource_checked(key: str, message: dict) -> None:
     value = message['value']
     if resource:
         for key in ['status', 'timeout', 'check_date']:
-            if value[key]:
+            if value.get(key, None) is not None:
                 resource.extras[f'check:{key}'] = value[key]
         resource.save()
     else:

--- a/udata_event_consumer/dataset/event.py
+++ b/udata_event_consumer/dataset/event.py
@@ -10,14 +10,14 @@ def concat_location(location: dict) -> str:
     Return an url from an object storage location object.
     Input example:
     {
-        "url": "http://minio:9000/",
+        "netloc": "http://minio:9000/",
         "bucket": "udata",
         "key": "data/71cacba9-4ffd-4ea8-bc3e-694425ddf006"
     }
     would return the following string:
     "http://minio:9000/udata/data/71cacba9-4ffd-4ea8-bc3e-694425ddf006"
     '''
-    return '/'.join([location['url'].strip('/'), location['bucket'], location['key']])
+    return '/'.join([location['netloc'].strip('/'), location['bucket'], location['key']])
 
 
 def consume_message_resource_analysed(key: str, message: dict) -> None:
@@ -28,19 +28,19 @@ def consume_message_resource_analysed(key: str, message: dict) -> None:
     log.info('Consuming message analysed')
     resource = get_resource(UUID(key))
     value = message['value']
+    service = message["service"]
     if resource:
-        if message['service'] == 'udata-hydra':
-            resource.extras['analysis:error'] = value['error']
-            resource.extras['analysis:filesize'] = value['filesize']
-            resource.extras['analysis:mime'] = value['mime']
-        elif message['service'] == 'detective':
-            resource.extras['analysis:data_location'] = concat_location(value['data_location'])
+        if service == 'udata-hydra':
+            for key in ['error', 'filesize', 'mime']:
+                if value[key]:
+                    resource.extras[f'analysis:{key}'] = value[key]
+        elif service == 'csvdetective':
             resource.extras['analysis:report_location'] = concat_location(value['report_location'])
-            resource.extras['analysis:schema_location'] = concat_location(value['schema_location'])
+            resource.extras['analysis:tableschema_location'] = concat_location(value['tableschema_location'])
             resource.extras['analysis:encoding'] = value['encoding']
             resource.extras['analysis:delimiter'] = value['delimiter']
         else:
-            log.warn(f'Unexpected service for resource analysed topic for key {key}')
+            log.warn(f'Unexpected service {service} for resource analysed topic for key {key}')
         resource.save()
     else:
         log.warn(f'No resource found for key {key}')
@@ -53,7 +53,7 @@ def consume_message_resource_stored(key: str, message: dict) -> None:
     log.info('Consuming message stored')
     resource = get_resource(UUID(key))
     if resource:
-        resource.extras['store:location'] = concat_location(message['value']['data_location'])
+        resource.extras['store:data_location'] = concat_location(message['value']['data_location'])
         resource.save()
     else:
         log.warn(f'No resource found for key {key}')
@@ -68,9 +68,9 @@ def consume_message_resource_checked(key: str, message: dict) -> None:
     resource = get_resource(UUID(key))
     value = message['value']
     if resource:
-        resource.extras['check:status'] = value['status']
-        resource.extras['check:timeout'] = value['timeout']
-        resource.extras['check:check_date'] = value['check_date']
+        for key in ['status', 'timeout', 'check_date']:
+            if value[key]:
+                resource.extras[f'check:{key}'] = value[key]
         resource.save()
     else:
         log.warn(f'No resource found for key {key}')


### PR DESCRIPTION
Related to https://github.com/etalab/udata-event-orchestration/pull/3

* Use `netloc` instead of `url` keyword
* Read `check_date` in value body instead of meta
* Read csvdetective data, report and schema locations
* Read `data_location` instead of `location` in hydra messages

An example of stored extras would be:
```
{
    'store:data_location': 'http://minio:9000/udata/data/6065c5cd9f89bfd828bcbf5c/503c39b0-58d8-45fe-ace0-55795bb0a6b7',
    'analysis:filesize': 73,
    'analysis:mime': 'text/plain',
    'check:check_date': '2022-07-26 09:17:46.979456',
    'check:status': 200,
    'analysis:delimiter': ';',
    'analysis:encoding': 'ASCII',
    'analysis:report_location': 'http://minio:9000/udata/report/6065c5cd9f89bfd828bcbf5c/503c39b0-58d8-45fe-ace0-55795bb0a6b7.json',
    'analysis:tableschema_location': 'http://minio:9000/udata/schemas/6065c5cd9f89bfd828bcbf5c/503c39b0-58d8-45fe-ace0-55795bb0a6b7'
}
```